### PR TITLE
Adding cacheDir

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -7,6 +7,12 @@
 */
 
 // Global default params, used in configs
+singularity{
+  enabled                         = true	
+  //runOptions                      = "--bind /fs1/ --bind /local/ --bind /fs2/ --bind /mnt/beegfs/"
+  cacheDir                        = "/fs1/pipelines/paul_test/sailendra/singularity"
+}
+
 params {
 
     // Input options


### PR DESCRIPTION
Adding a cacheDir to nextflow.config to avoid automatic downloading of singularity images on every nextflow run. Testing PR dev -> lund_main.

